### PR TITLE
Fix deprecations for outputs

### DIFF
--- a/.github/workflows/backups.yml
+++ b/.github/workflows/backups.yml
@@ -1,4 +1,4 @@
-name: Backup Github Respository
+name: Backup Github Repository
 
 on:
   workflow_call:
@@ -22,7 +22,7 @@ on:
 
 jobs:
   deploy:
-    name: Backup Respository To S3 Bucket
+    name: Backup Repository To S3 Bucket
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/backups.yml
+++ b/.github/workflows/backups.yml
@@ -2,9 +2,6 @@ name: Backup Github Respository
 
 on:
   workflow_call:
-    ###
-    ### Variables
-    ###
     inputs:
       enabled:
         description: 'Determines whether this workflow is enabled at all (will run or skip).'
@@ -15,9 +12,6 @@ on:
         required: true
         type: string
         default: eu-central-1
-    ###
-    ### Secrets
-    ###
     secrets:
       bucket_name:
         description: 'The name of the bucket to backup the repository tar'

--- a/.github/workflows/backups.yml
+++ b/.github/workflows/backups.yml
@@ -32,9 +32,9 @@ jobs:
       - name: Configurations
         id: settings
         run: |
-          echo "::set-output name=org::${{ github.event.repository.organization }}"
-          echo "::set-output name=repo::${{ github.event.repository.name }}"
-          echo "::set-output name=compress_repo::${{ github.event.repository.name }}-$(date +'%Y-%m-%d_%H-%M').tar.gz"
+          echo "org=${{ github.event.repository.organization }}" >> $GITHUB_OUTPUT
+          echo "repo=${{ github.event.repository.name }}" >> $GITHUB_OUTPUT
+          echo "gzip=${{ github.event.repository.name }}-$(date +'%Y-%m-%d_%H-%M').tar.gz" >> $GITHUB_OUTPUT
 
       - name: Clone Repository
         uses: actions/checkout@v3
@@ -42,7 +42,7 @@ jobs:
       - name: Compress Repository
         working-directory: ".."
         run: |
-          tar -czvf ${{ steps.settings.outputs.compress_repo }} ${{ steps.settings.outputs.repo }}
+          tar -czvf ${{ steps.settings.outputs.gzip }} ${{ steps.settings.outputs.repo }}
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -53,4 +53,4 @@ jobs:
       - name: Backup Repository to S3 Bucket
         working-directory: ".."
         run: |
-          aws s3 cp ${{ steps.settings.outputs.compress_repo }} s3://${{ secrets.bucket_name }}/${{ steps.settings.outputs.repo }}/
+          aws s3 cp ${{ steps.settings.outputs.gzip }} s3://${{ secrets.bucket_name }}/${{ steps.settings.outputs.repo }}/

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -2,7 +2,6 @@ name: Release Drafter
 
 on:
   push:
-    # branches to consider in the event; optional, defaults to all
     branches:
       - master
 
@@ -10,7 +9,6 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      # Drafts your next Release notes as Pull Requests are merged into "master"
       - uses: release-drafter/release-drafter@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This will address deprecated workflow function for outputs: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/